### PR TITLE
fix main entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 			}
 		]
 	},
-	"main": "./out/extension.js",
+	"main": "./out/extension",
 	"scripts": {
 		"vscode:prepublish": "npm run package",
 		"compile": "webpack",


### PR DESCRIPTION
other package.json `main` entries don't have the `.js`, so we shouldn't either. for example:

![image](https://github.com/user-attachments/assets/77b3a7e2-972f-40ba-9db2-a9c774ab6d51)

![image](https://github.com/user-attachments/assets/e28b39bf-05f4-4528-86b6-7fa98ba9c369)
