### PR TITLE
when alt text is boilerplate, return generate quick fix, not refine

### DIFF
--- a/src/altTextQuickFixProvider.ts
+++ b/src/altTextQuickFixProvider.ts
@@ -88,14 +88,19 @@ export class AltTextQuickFixProvider implements vscode.CodeActionProvider<ImageC
 			codeAction.edit = new vscode.WorkspaceEdit();
 			const edit = new vscode.WorkspaceEdit();
 			if (codeAction.isHtml) {
-				let addedTagIndex = 0;
+				let additionalCharsToRemove = 0;
 				if (!codeAction.currentLine.includes('alt=')) {
 					altText = `img alt="${altText}"`;
-					addedTagIndex = 3;
+					additionalCharsToRemove = 3;
 				}
-				edit.replace(codeAction.document.uri, new vscode.Range(codeAction.range.start.line, codeAction.altTextStartIndex, codeAction.range.start.line, codeAction.altTextStartIndex + addedTagIndex), altText);
+				edit.replace(codeAction.document.uri, new vscode.Range(codeAction.range.start.line, codeAction.altTextStartIndex, codeAction.range.start.line, codeAction.altTextStartIndex + additionalCharsToRemove), altText);
 			} else {
-				edit.insert(codeAction.document.uri, new vscode.Position(codeAction.range.start.line, codeAction.altTextStartIndex), altText);
+				const isBoilerplate = codeAction.currentLine.includes('![alt text]');
+				if (isBoilerplate) {
+					edit.replace(codeAction.document.uri, new vscode.Range(codeAction.range.start.line, codeAction.altTextStartIndex, codeAction.range.start.line, codeAction.altTextStartIndex + 8), altText);
+				} else {
+					edit.insert(codeAction.document.uri, new vscode.Position(codeAction.range.start.line, codeAction.altTextStartIndex), altText);
+				}
 			}
 			codeAction.edit = edit;
 			return codeAction;

--- a/src/test/altTextGeneratorQuickFix.test.ts
+++ b/src/test/altTextGeneratorQuickFix.test.ts
@@ -44,9 +44,21 @@ describe('Alt text quick fixes: extractImageInfo', () => {
 				assert.equal(altTextLength, 0);
 			});
 		});
+		describe('Alt text is boilerplate: should provide result', () => {
+			it('Markdown Image syntax', () => {
+				const markdownImage = '![alt text](path/to/image.png)';
+				const match = extractImageAttributes(markdownImage, refineExisting);
+				assert(match);
+				const { imagePath, altTextStartIndex, isHTML, altTextLength } = match;
+				assert.equal(imagePath, 'path/to/image.png');
+				assert.equal(altTextStartIndex, 2);
+				assert.equal(isHTML, false);
+				assert.equal(altTextLength, 8);
+			});
+		});
 		describe('Alt text exists: should return undefined', () => {
 			it('Markdown Image syntax', () => {
-				const markdownImageWithAlt = '![alt text](path/to/image.png)';
+				const markdownImageWithAlt = '![some word](path/to/image.png)';
 				const match = extractImageAttributes(markdownImageWithAlt, refineExisting);
 				assert(!match);
 			});
@@ -64,7 +76,7 @@ describe('Alt text quick fixes: extractImageInfo', () => {
 			});
 
 			it('Markdown Link with Image syntax', () => {
-				const markdownLinkImageWithAlt = '[![alt text](path/to/image.png)](http://example.com)';
+				const markdownLinkImageWithAlt = '[![some word](path/to/image.png)](http://example.com)';
 				const match = extractImageAttributes(markdownLinkImageWithAlt, refineExisting);
 				assert(!match);
 			});
@@ -93,16 +105,23 @@ describe('Alt text quick fixes: extractImageInfo', () => {
 				assert(!match);
 			});
 		});
+		describe('Alt text is boilerplate: should return undefined', () => {
+			it('Markdown Image syntax', () => {
+				const markdownImage = '![alt text](path/to/image.png)';
+				const match = extractImageAttributes(markdownImage, refineExisting);
+				assert(!match);
+			});
+		});
 		describe('Alt text exists: should provide result', () => {
 			it('Markdown Image syntax', () => {
-				const markdownImageWithAlt = '![alt text](path/to/image.png)';
+				const markdownImageWithAlt = '![some word](path/to/image.png)';
 				const match = extractImageAttributes(markdownImageWithAlt, refineExisting);
 				assert(match);
 				const { imagePath, altTextStartIndex, isHTML, altTextLength } = match;
 				assert.equal(imagePath, 'path/to/image.png');
 				assert.equal(altTextStartIndex, 2);
 				assert.equal(isHTML, false);
-				assert.equal(altTextLength, 8);
+				assert.equal(altTextLength, 9);
 			});
 
 			it('HTML Image syntax, alt before source', () => {
@@ -128,7 +147,7 @@ describe('Alt text quick fixes: extractImageInfo', () => {
 			});
 
 			it('Markdown Link with Image syntax', () => {
-				const markdownLinkImageWithAlt = '[![alt text](path/to/image.png)](http://example.com)';
+				const markdownLinkImageWithAlt = '[![one word](path/to/image.png)](http://example.com)';
 				const match = extractImageAttributes(markdownLinkImageWithAlt, refineExisting);
 				assert(match);
 				const { imagePath, altTextStartIndex, isHTML, altTextLength } = match;

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -25,12 +25,12 @@ export function extractImageAttributes(line: string, refineExisting?: boolean): 
 		isHTML = false;
 
 		// If refineExisting is true, ensure altText already exists
-		if (refineExisting && !altText) {
+		if (refineExisting && (!altText || altText === 'alt text')) {
 			return undefined;
 		}
 
 		// If refineExisting is false, ensure altText does not exist
-		if (!refineExisting && altText) {
+		if (!refineExisting && (altText && altText !== 'alt text')) {
 			return undefined;
 		}
 


### PR DESCRIPTION
fix #9553