### PR TITLE
bump copilot vision version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-copilot-vision",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-copilot-vision",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.29.0",
 				"@azure/core-auth": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"chatReferenceBinaryData",
 		"codeActionAI"
 	],
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"engines": {
 		"vscode": "^1.95.0"
 	},


### PR DESCRIPTION
fixes `ERROR  ms-vscode.vscode-copilot-vision v0.1.0 already exists.` when publishing
