### PR TITLE
skip non-image references for vision requests

### DIFF
--- a/src/apiFacade.ts
+++ b/src/apiFacade.ts
@@ -66,7 +66,7 @@ export class OpenAIApi implements ApiFacade {
 
 			for (const data of content) {
 				const base64 = data.toString('base64');
-				prompts.push({ type: 'image_url', image_url: { url: `data:${mimeType};base64,${base64}` } });
+				prompts.push({ type: 'image_url', image_url: { url: `data:${mimeType};base64,${base64}`, detail: 'high' } });
 			}
 
 			const openAi = new OpenAI({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,8 +61,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (reference.value instanceof vscode.Uri) {
 				const result = await getBufferAndMimeTypeFromUri(reference.value);
 				if (!result) {
-					stream.markdown(vscode.l10n.t(`The file is not an image.`));
-					return { metadata: { command: '' } };
+					continue;
 				}
 				mimeType = result.mimeType;
 				base64Strings.push(result.buffer);


### PR DESCRIPTION
will only use image (chatReferenceBinaryData) refefrences as attachments if any with the `@vision` agent